### PR TITLE
fix for error introduced by binutils 2.21.0 --> 2.21.1 update

### DIFF
--- a/patches/patch-binutils-2.21.1-svc-cortexm3.diff
+++ b/patches/patch-binutils-2.21.1-svc-cortexm3.diff
@@ -1,0 +1,33 @@
+===================================================================
+RCS file: /cvs/src/src/include/opcode/arm.h,v
+retrieving revision 1.24
+retrieving revision 1.25
+diff -u -r1.24 -r1.25
+--- src/include/opcode/arm.h	2010/11/15 10:03:05	1.24
++++ src/include/opcode/arm.h	2011/04/11 15:23:09	1.25
+@@ -1,5 +1,5 @@
+ /* ARM assembler/disassembler support.
+-   Copyright 2004, 2010 Free Software Foundation, Inc.
++   Copyright 2004, 2010, 2011 Free Software Foundation, Inc.
+ 
+    This file is part of GDB and GAS.
+ 
+@@ -109,7 +109,8 @@
+ #define ARM_AEXT_V6KT2  (ARM_AEXT_V6T2 | ARM_EXT_V6K)
+ #define ARM_AEXT_V6ZT2  (ARM_AEXT_V6T2 | ARM_EXT_SEC)
+ #define ARM_AEXT_V6ZKT2 (ARM_AEXT_V6T2 | ARM_EXT_V6K | ARM_EXT_SEC)
+-#define ARM_AEXT_V7_ARM	(ARM_AEXT_V6KT2 | ARM_EXT_V7 | ARM_EXT_BARRIER)
++#define ARM_AEXT_V7_ARM	(ARM_AEXT_V6KT2 | ARM_EXT_V7 | ARM_EXT_BARRIER \
++    | ARM_EXT_OS)
+ #define ARM_AEXT_V7A	(ARM_AEXT_V7_ARM | ARM_EXT_V7A)
+ #define ARM_AEXT_V7R	(ARM_AEXT_V7_ARM | ARM_EXT_V7R | ARM_EXT_DIV)
+ #define ARM_AEXT_NOTM \
+@@ -148,7 +149,7 @@
+                          | FPU_VFP_EXT_V3 | FPU_NEON_EXT_V1 | FPU_VFP_EXT_D32)
+ #define FPU_FPA		(FPU_FPA_EXT_V1 | FPU_FPA_EXT_V2)
+ 
+-/* Deprecated */
++/* Deprecated.  */
+ #define FPU_ARCH_VFP	ARM_FEATURE (0, FPU_ENDIAN_PURE)
+ 
+ #define FPU_ARCH_FPE	ARM_FEATURE (0, FPU_FPA_EXT_V1)

--- a/summon-arm-toolchain
+++ b/summon-arm-toolchain
@@ -335,6 +335,10 @@ fi
 
 if [ ! -e ${STAMPS}/${BINUTILS}.build ]; then
     unpack ${BINUTILS}
+    log "Patching binutils to allow SVC support on cortex-m3"
+    cd ${BINUTILS}
+    patch -p1 -i ../patches/patch-binutils-2.21.1-svc-cortexm3.diff
+    cd ..
     cd build
     log "Configuring ${BINUTILS}"
     ../${BINUTILS}/configure --target=${TARGET} \


### PR DESCRIPTION
Patch binutils 2.21.1 to avoid the error
"Error: SVC is not permitted on this architecture"

See http://sourceware.org/bugzilla/show_bug.cgi?id=12296
