### PR TITLE
SSL Error within launchpad servers

### DIFF
--- a/summon-arm-toolchain
+++ b/summon-arm-toolchain
@@ -230,7 +230,7 @@ esac
 function fetch {
     if [ ! -e ${STAMPS}/$1.fetch ]; then
         log "Downloading $1 sources..."
-        wget -c --no-passive-ftp $2 && touch ${STAMPS}/$1.fetch
+        wget -c --no-passive-ftp --no-check-certificate $2 && touch ${STAMPS}/$1.fetch
     fi
 }
 


### PR DESCRIPTION
Because of a ssl error within the launchpad servers, wget wont'n download the files. Added the --no-check-certificate parameter to wget to walkaround this bug.
