### PR TITLE
Fixes

### DIFF
--- a/summon-arm-toolchain
+++ b/summon-arm-toolchain
@@ -490,7 +490,7 @@ if [ ! -e ${STAMPS}/${OOCD}.build ]; then
     unpack ${OOCD}
     log "Patching binutils to allow SVC support on cortex-m3"
     cd ${OOCD}
-    patch -p1 -i ../../patches/patch-openocd-arm7m-registers.diff
+    patch -p1 -i ../patches/patch-openocd-arm7m-registers.diff
     cd ..
     cd build
     log "Configuring openocd-${OOCD}"

--- a/summon-arm-toolchain
+++ b/summon-arm-toolchain
@@ -136,7 +136,6 @@ fi
 
 BINUTILS=binutils-2.21.1
 NEWLIB=newlib-1.19.0
-GDB=gdb-7.3.1
 OOCD=openocd-0.5.0
 OOCD_GIT=9e1a16690e669b895dce7c3951b1fe893bfd6149
 LIBCMSIS=
@@ -242,7 +241,7 @@ esac
 function fetch {
     if [ ! -e ${STAMPS}/$1.fetch ]; then
         log "Downloading $1 sources..."
-        wget -c --no-passive-ftp $2 && touch ${STAMPS}/$1.fetch
+        wget -c --no-passive-ftp --no-check-certificate $2 && touch ${STAMPS}/$1.fetch
     fi
 }
 


### PR DESCRIPTION
These fixes were necessary to successfully build on 10.6.8 using ./summon-arm-toolchain PREFIX=/usr/local/ARM-Toolchain SUDO=sudo OOCD_EN=0
OOCD build failed but as I do not need it I didn't look further into this.

Greetings
Felix
