### PR TITLE
accept a DESTDIR environment variable for libopencm3

### DIFF
--- a/summon-arm-toolchain
+++ b/summon-arm-toolchain
@@ -565,8 +565,8 @@ if [ ! -e ${STAMPS}/${LIBOPENCM3}.build ]; then
     unpack ${LIBOPENCM3}
     cd ${LIBOPENCM3}
     log "Building ${LIBOPENCM3}"
-    make PREFIX=${TARGET} DESTDIR=${PREFIX}
-    install ${LIBOPENCM3} PREFIX=${TARGET} DESTDIR=${PREFIX} install
+    make PREFIX=${TARGET} DESTDIR=${DESTDIR}${DESTDIR:+/}${PREFIX}
+    install ${LIBOPENCM3} PREFIX=${TARGET} DESTDIR=${DESTDIR}${DESTDIR:+/}${PREFIX} install
     cd ..
     log "Cleaning up ${LIBOPENCM3}"
     touch ${STAMPS}/${LIBOPENCM3}.build


### PR DESCRIPTION
differing between ${PREFIX} and ${DESTDIR}/${PREFIX} is important for
creating a debian package, where all hardwired paths have to be set to
${PREFIX}/something, while the actual installation will go to
${DESTDIR}/${PREFIX}/something.

as opposed to the seemingly abandoned approach at DESTDIR from destdir_support branch, this patch wants to work just for already set environment variables, and not for argument passing. as all build systems but libopencm3's already respect a DESTDIR variable, barely anything needs changing.
