### PR TITLE
Update to openocd-0.6.0 and doc apt-get zlib

### DIFF
--- a/README
+++ b/README
@@ -138,7 +138,7 @@ Notes for Linux users:
 You need to install several packages. On Debian just run:
 
   $ apt-get install flex bison libgmp3-dev libmpfr-dev libncurses5-dev \
-    libmpc-dev autoconf texinfo build-essential libftdi-dev zlib1g-dev
+    libmpc-dev autoconf texinfo build-essential libftdi-dev zlib1g-dev git
 
 You may want to try running the following command instead too:
 

--- a/README
+++ b/README
@@ -138,7 +138,7 @@ Notes for Linux users:
 You need to install several packages. On Debian just run:
 
   $ apt-get install flex bison libgmp3-dev libmpfr-dev libncurses5-dev \
-    libmpc-dev autoconf texinfo build-essential libftdi-dev
+    libmpc-dev autoconf texinfo build-essential libftdi-dev zlib1g-dev
 
 You may want to try running the following command instead too:
 

--- a/summon-arm-toolchain
+++ b/summon-arm-toolchain
@@ -6,7 +6,7 @@
 # Requirements (example is for Debian, replace package names as needed):
 #
 # apt-get install flex bison libgmp3-dev libmpfr-dev libncurses5-dev \
-# libmpc-dev autoconf texinfo build-essential libftdi-dev zlib1g-dev
+# libmpc-dev autoconf texinfo build-essential libftdi-dev zlib1g-dev git
 #
 # Or on Ubuntu Maverick give `apt-get build-dep gcc-4.5` a try.
 #

--- a/summon-arm-toolchain
+++ b/summon-arm-toolchain
@@ -6,7 +6,7 @@
 # Requirements (example is for Debian, replace package names as needed):
 #
 # apt-get install flex bison libgmp3-dev libmpfr-dev libncurses5-dev \
-# libmpc-dev autoconf texinfo build-essential zlib1g-dev
+# libmpc-dev autoconf texinfo build-essential libftdi-dev zlib1g-dev
 #
 # Or on Ubuntu Maverick give `apt-get build-dep gcc-4.5` a try.
 #

--- a/summon-arm-toolchain
+++ b/summon-arm-toolchain
@@ -136,7 +136,7 @@ fi
 
 BINUTILS=binutils-2.21.1
 NEWLIB=newlib-1.19.0
-OOCD=openocd-0.6.0-rc1
+OOCD=openocd-0.6.0
 OOCD_GIT=
 LIBCMSIS=
 LIBCMSIS_GIT=v1.10-3
@@ -334,7 +334,7 @@ fetch ${GDB} ${GDBURL}
 
 if [ ${OOCD_EN} != 0 ]; then
 	if [ "x${OOCD_GIT}" == "x" ]; then
-		fetch ${OOCD} http://sourceforge.net/projects/openocd/files/openocd/0.6.0-rc1/${OOCD}.tar.bz2
+		fetch ${OOCD} http://sourceforge.net/projects/openocd/files/openocd/0.6.0/${OOCD}.tar.bz2
 	else
 		clone oocd ${OOCD_GIT} git://openocd.git.sourceforge.net/gitroot/openocd/openocd ./bootstrap
 	fi

--- a/summon-arm-toolchain
+++ b/summon-arm-toolchain
@@ -6,7 +6,7 @@
 # Requirements (example is for Debian, replace package names as needed):
 #
 # apt-get install flex bison libgmp3-dev libmpfr-dev libncurses5-dev \
-# libmpc-dev autoconf texinfo build-essential
+# libmpc-dev autoconf texinfo build-essential zlib1g-dev
 #
 # Or on Ubuntu Maverick give `apt-get build-dep gcc-4.5` a try.
 #


### PR DESCRIPTION
Compiled on a fresh Ubuntu 12.04 Desktop 32-bit download on VirtualBox. Tested firmware build and debug with openocd.
