### PR TITLE
Fix build with Texinfo 5.0

### DIFF
--- a/patches/patch-fix-texinfo-5.patch
+++ b/patches/patch-fix-texinfo-5.patch
@@ -1,0 +1,12 @@
+--- gcc/Makefile.in.orig	2013-02-25 16:01:24.156624260 +0100
++++ gcc/Makefile.in	2013-02-25 16:02:10.273290463 +0100
+@@ -4303,8 +4303,7 @@
+ 
+ doc/%.info: %.texi
+ 	if [ x$(BUILD_INFO) = xinfo ]; then \
+-		$(MAKEINFO) $(MAKEINFOFLAGS) -I . -I $(gcc_docdir) \
+-			-I $(gcc_docdir)/include -o $@ $<; \
++		touch $@; \
+ 	fi
+ 
+ # Duplicate entry to handle renaming of gccinstall.info

--- a/summon-arm-toolchain
+++ b/summon-arm-toolchain
@@ -427,6 +427,7 @@ if [ ! -e ${STAMPS}/${GCC}-${NEWLIB}.build ]; then
 	cd ${GCC}
 	patch -p0 -i ../patches/patch-gcc-config-arm-t-arm-elf.diff
 	patch -p0 -i ../patches/patch-libgcc-divide-exceptions.diff
+	patch -p0 -i ../patches/patch-fix-texinfo-5.patch
 	cd ..
     fi
 


### PR DESCRIPTION
Texinfo 5.0 broke the GCC 4.7.2 build. As it only touches the documentation and not the actual code, here is a quick patch to allow building GCC without the doc. This may not be the cleanest way to do it, but really few people use this doc anyways.
We can only hope it will be fixed in the next version of gcc.
