### PR TITLE
Update to gcc-4.8.0

### DIFF
--- a/patches/patch-gcc-4.8.0-libgcc-divide-exceptions.diff
+++ b/patches/patch-gcc-4.8.0-libgcc-divide-exceptions.diff
@@ -1,0 +1,20 @@
+--- libgcc/Makefile.in.orig	Mon Feb  4 23:06:20 2013
++++ libgcc/Makefile.in	Mon Mar 25 15:46:52 2013
+@@ -492,7 +492,7 @@
+ ifeq ($(LIB2_DIVMOD_EXCEPTION_FLAGS),)
+ # Provide default flags for compiling divmod functions, if they haven't been
+ # set already by a target-specific Makefile fragment.
+-LIB2_DIVMOD_EXCEPTION_FLAGS := -fexceptions -fnon-call-exceptions
++LIB2_DIVMOD_EXCEPTION_FLAGS := -fno-exceptions -fnon-call-exceptions
+ endif
+ 
+ # Build LIB2_DIVMOD_FUNCS.
+@@ -813,7 +813,7 @@
+ # libgcc_eh.a, only LIB2ADDEH matters.  If we do, only LIB2ADDEHSTATIC and
+ # LIB2ADDEHSHARED matter.  (Usually all three are identical.)
+ 
+-c_flags := -fexceptions
++c_flags := -fno-exceptions
+ 
+ ifeq ($(enable_shared),yes)
+ 

--- a/summon-arm-toolchain
+++ b/summon-arm-toolchain
@@ -116,9 +116,9 @@ echo "CPUS=$CPUS"
 ##############################################################################
 if [ ${USE_LINARO} == 0 ] ; then
 	# For FSF GCC:
-	GCCVERSION=4.7.2
+	GCCVERSION=4.8.0
 	GCC=gcc-${GCCVERSION}
-	GCCURL=http://ftp.gnu.org/gnu/gcc/${GCC}/${GCC}.tar.gz
+	GCCURL=http://ftp.gnu.org/gnu/gcc/${GCC}/${GCC}.tar.bz2
 
 	# For FSF GDB:
 	GDBVERSION=7.5.1
@@ -426,7 +426,7 @@ if [ ! -e ${STAMPS}/${GCC}-${NEWLIB}.build ]; then
 	log "Patching gcc to add multilib support"
 	cd ${GCC}
 	patch -p0 -i ../patches/patch-gcc-config-arm-t-arm-elf.diff
-	patch -p0 -i ../patches/patch-libgcc-divide-exceptions.diff
+	patch -p0 -i ../patches/patch-${GCC}-libgcc-divide-exceptions.diff
 	cd ..
     fi
 


### PR DESCRIPTION
Added libgcc patch for gcc-4.8.0 and updated the SAT script. 
Tested both on Windows 7 and Ubuntu 12.10 - builds were successfully finished for main features (binutils, gcc, newlib (and newlib-nano), gdb), the resulting toolchain was tested to build firmwares for stm32f407 and stm32f215 with previously compiled libopencm3.
However, I wasn't able to build libopencm3 using the toolchain due to the following error:
../../cm3/vector.c: In function 'reset_handler':
../../cm3/vector.c:70:1: internal compiler error: in advance_target_bb, at shed-rgn.c:3552
0x78eb92 advance_target_bb
I'll try to investigate that error later, but if someone has any information about it I'd be grateful to hear it.On the good side - I've noticed a significant code footprint reduction compared to 4.7.2 (but maybe it's just for my code).
