### PR TITLE
Check if archives are already unpacked

### DIFF
--- a/summon-arm-toolchain
+++ b/summon-arm-toolchain
@@ -303,7 +303,11 @@ function log {
 function unpack {
     log Unpacking $*
     # Use 'auto' mode decompression.  Replace with a switch if tar doesn't support -a
-    ARCHIVE=$(ls ${SOURCES}/$1.tar.*)
+	if [ -e $1 ]; then
+		log Already Uncompressed
+		return
+	fi
+	ARCHIVE=$(ls ${SOURCES}/$1.tar.*)
     case ${ARCHIVE} in
 	*.bz2)
 	    echo "archive type bz2"


### PR DESCRIPTION
If archives are already unpacked we do not want to extract them again.
It will help, if you have to recompile for some reason.
